### PR TITLE
Improve jq list with --compact and --filepath-replace args

### DIFF
--- a/jobqueueing/argparse_helpers.py
+++ b/jobqueueing/argparse_helpers.py
@@ -135,9 +135,17 @@ def add_ext_submit_arguments(parser):
 
 def add_listing_arguments(parser):
     group = parser.add_argument_group('Listing control arguments')
-    group.add_argument(
-        '-f', '--full', action='store_true',
+    mutex_group = parser.add_mutually_exclusive_group()
+    mutex_group.add_argument(
+        '-C', '--compact', action='store_true',
+        help='Display compact listing')
+    mutex_group.add_argument(
+        '-F', '--full', action='store_true',
         help='Display full listing')
+    group.add_argument(
+        '-f', '--filepath-replace', dest='filepath_replace', nargs=2,
+        help='Search/replace filepath string for more readable listing'
+    )
     group.add_argument(
         '-i', '--input-filepath', dest='input_filepath',
         help='Input filepath (partial match)')

--- a/scripts/jq
+++ b/scripts/jq
@@ -77,7 +77,14 @@ def alter_params(session, args):
 def list(session, args):
     return list_entries(
         session,
-         **args_dict(args, 'input_filepath pbs_job_id status full'.split())
+         **args_dict(args,
+                     '''
+                     input_filepath
+                     pbs_job_id
+                     status
+                     filepath_replace
+                     compact
+                     full'''.split())
     )
 
 


### PR DESCRIPTION
Compact listing (1 line per entry).
Filepath replacement via regex: -f pattern replace, to enable arbitrary rewriting of filepaths for easier viewing/analysis.