### PR TITLE
Ensure that the cdo py module can find cdo bin

### DIFF
--- a/jobqueueing/gc_submit.py
+++ b/jobqueueing/gc_submit.py
@@ -36,6 +36,10 @@ module list
 source {qe.py_venv}/bin/activate
 which python
 
+# The cdo python module executes Popen w/ shell=False
+# and in effect completely ignores the $PATH variable
+export CDO=$(which cdo)
+
 # Copy NetCDF file to $TMPDIR/climo/input
 indir=$TMPDIR/climo/input
 echo mkdir -p $indir && cp {qe.input_filepath} $indir
@@ -81,6 +85,10 @@ module load cdo-bin
 module list
 source {qe.py_venv}/bin/activate
 which python
+
+# The cdo python module executes Popen w/ shell=False
+# and in effect completely ignores the $PATH variable
+export CDO=$(which cdo)
 
 # Copy NetCDF file to $TMPDIR/climo/input
 indir=$TMPDIR/climo/input


### PR DESCRIPTION
It turns out that the cdo Python library, executes cdo with Popen(..., shell=False).
As such, it completely ignores the PATH variable, and makes it impossible to find the cdo binary if installed in a non-standard location.

It *does* however, search for an environment variable, `CDO`, and if set uses that for the path to the cdo binary.

This PR simply sets that environment variable in the PBS script, so that the Python library is able to find it.